### PR TITLE
New test for Issue #37

### DIFF
--- a/tests/array.insert.test.js
+++ b/tests/array.insert.test.js
@@ -46,6 +46,54 @@ describe('redux-pouchdb array', () => {
     store.dispatch({
       type: INCREMENT
     })
+
+    // console.log('--INC---')
+
+    await waitSync(reducerName)
+    // console.log('--waited---')
+
+    const docs2 = await loadArray(db)(reducerName)
+    // console.log('--loaded2---')
+
+    const x2a = store
+      .getState()
+      .map(a => a.x)
+      .sort()
+      .join()
+    const x2b = docs2
+      .map(a => a.x)
+      .sort()
+      .join()
+
+    // console.log('store', x2a, 'doc', x2b)
+    x2a.should.be.equal(x2b)
+
+    done()
+  })
+
+  it('should persist store state as array and insert when multple actions modify the store', async done => {
+    // console.log('--go---')
+    let store = createStore(finalReducer)
+    persistStore(store)
+    // console.log('--persisted---')
+
+    const success = await waitSync(reducerName)
+    success.should.be.equal(true)
+
+    // const x1a = store
+    //   .getState()
+    //   .map(a => a.x)
+    //   .sort()
+    //   .join()
+    // console.log('store', x1a)
+
+    store.dispatch({
+      type: INCREMENT
+    })
+    store.dispatch({
+      type: INCREMENT
+    })
+
     // console.log('--INC---')
 
     await waitSync(reducerName)


### PR DESCRIPTION
Test that demonstrates issue #37 

```
 FAIL  tests/array.insert.test.js (11.548s)
  ● Console

    console.log src/utils/log.js:3
      waitSync true true true
    console.log src/utils/log.js:3
      waitSync true true true
    console.log src/utils/log.js:3
      waitSync true true true
    console.error src/utils/saveArray.js:75
      PouchError {
        status: 400,
        name: 'bad_request',
        message: 'Document must be a JSON object',
        error: true
      }
    console.log src/utils/log.js:3
      waitSync true true false
    console.log src/utils/log.js:3
      waitSync true true false
    console.log src/utils/log.js:3
      waitSync true true false
    console.log src/utils/log.js:3
      waitSync true true false
    console.log src/utils/log.js:3
      waitSync true true false
    console.log src/utils/log.js:3
      waitSync true true false
    console.log src/utils/log.js:3
      waitSync true true false
    console.log src/utils/log.js:3
      waitSync true true false
    console.log src/utils/log.js:3
      waitSync true true false
    console.log src/utils/log.js:3
      waitSync true true false
    console.log src/utils/log.js:3
      waitSync true true false
    console.log src/utils/log.js:3
      waitSync true true false
    console.log src/utils/log.js:3
      waitSync true true false
    console.log src/utils/log.js:3
      waitSync true true false
    console.log src/utils/log.js:3
      waitSync true true false
    console.log src/utils/log.js:3
      waitSync true true false
    console.log src/utils/log.js:3
      waitSync true true false
    console.log src/utils/log.js:3
      waitSync true true false
    console.log src/utils/log.js:3
      waitSync true true false
    console.log src/utils/log.js:3
      waitSync true true false
    console.log src/utils/log.js:3
      waitSync true true false
    console.log src/utils/log.js:3
      waitSync true true false
    console.log src/utils/log.js:3
      waitSync true true false
    console.log src/utils/log.js:3
      waitSync true true false
    console.log src/utils/log.js:3
      waitSync true true false
    console.log src/utils/log.js:3
      waitSync true true false
    console.log src/utils/log.js:3
      waitSync true true false
    console.log src/utils/log.js:3
      waitSync true true false
    console.log src/utils/log.js:3
      waitSync true true false
    console.log src/utils/log.js:3
      waitSync true true false
    console.log src/utils/log.js:3
      waitSync true true false
    console.log src/utils/log.js:3
      waitSync true true false
    console.log src/utils/log.js:3
      waitSync true true false
    console.log src/utils/log.js:3
      waitSync true true false
    console.log src/utils/log.js:3
      waitSync true true false
    console.log src/utils/log.js:3
      waitSync true true false
    console.log src/utils/log.js:3
      waitSync true true false
    console.log src/utils/log.js:3
      waitSync true true false
    console.log src/utils/log.js:3
      waitSync true true false
    console.log src/utils/log.js:3
      waitSync true true false
    console.log src/utils/log.js:3
      waitSync true true false
    console.log src/utils/log.js:3
      waitSync true true false
    console.log src/utils/log.js:3
      waitSync true true false
    console.log src/utils/log.js:3
      waitSync true true false

  ● redux-pouchdb array › should persist store state as array and insert when multple actions modify the store

    : Timeout - Async callback was not invoked within the 5000ms timeout specified by jest.setTimeout.Timeout - Async callback was not invoked within the 5000ms timeout specified by jest.setTimeout.Error:

      72 |   })
      73 |
    > 74 |   it('should persist store state as array and insert when multple actions modify the store', async done => {
         |   ^
      75 |     // console.log('--go---')
      76 |     let store = createStore(finalReducer)
      77 |     persistStore(store)

      at new Spec (node_modules/jest-jasmine2/build/jasmine/Spec.js:116:22)
      at Suite.<anonymous> (tests/array.insert.test.js:74:3)
      at Object.<anonymous> (tests/array.insert.test.js:11:1)

Test Suites: 1 failed, 3 passed, 4 total
Tests:       1 failed, 4 passed, 5 total
Snapshots:   0 total
Time:        22.64s
Ran all test suites.
```